### PR TITLE
Certain pkg-config files for pango don't list all needed dependencies…

### DIFF
--- a/pango/pango.go
+++ b/pango/pango.go
@@ -17,7 +17,7 @@
 // Go bindings for Pango.
 package pango
 
-// #cgo pkg-config: fontconfig gobject-2.0 pango pangocairo
+// #cgo pkg-config: fontconfig gobject-2.0 glib-2.0 pango pangocairo
 // #include <pango/pango.h>
 // #include "pango.go.h"
 import "C"


### PR DESCRIPTION
…, so adding glib manually to the pkg-config list here